### PR TITLE
Do not lose ramXmpp instance on discord reconnect

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,7 +47,9 @@ function App() {
         discord.on('ready', () => {
             LogInfo('Connected to discord as ' + discord.user.username + " - (" + discord.user.id + ")");
 
-            ramXmpp = new Xmpp(config.jabber.userJid, config.jabber.userPass);
+            // Do not lose existing ramXmpp -- it will keep another connection
+            // open, multiplexing messages from Jabber conference.
+            ramXmpp = ramXmpp || new Xmpp(config.jabber.userJid, config.jabber.userPass);
             jabber = ramXmpp.getClient();
 
             this.registerXMPPListeners();


### PR DESCRIPTION
This manifests as either duplicate messages from Jabber in Discord, or
as an infinite reconnect loop (if JID is provided with resource, in
a@b/resource form).